### PR TITLE
chore: add prettier configuration and workflow

### DIFF
--- a/.github/workflows/lint-prettier-vitest.yaml
+++ b/.github/workflows/lint-prettier-vitest.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint-prettier-vitest.yaml
+++ b/.github/workflows/lint-prettier-vitest.yaml
@@ -1,0 +1,36 @@
+name: Lint, Prettier, and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-prettier-vitest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Run Prettier
+        run: npx prettier --check .
+        continue-on-error: true
+
+      - name: Run Vitest
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 JavaScript/TypeScript execution utilities for text formatting.
 
 [![ESLint](https://img.shields.io/badge/-ESLint-4B32C3?style=flat&logo=eslint&logoColor=white)](config/eslint/README.md)
+[![Prettier](https://img.shields.io/badge/-Prettier-FF69B4?style=flat&logo=prettier&logoColor=white)](config/prettier/README.md)
 
 ## Installation
 

--- a/config/prettier/README.md
+++ b/config/prettier/README.md
@@ -1,0 +1,48 @@
+# Prettier Configuration ✨
+
+## Overview
+
+This directory contains the Prettier configuration for the `console-tools-js` project. Prettier is our code formatter of choice for ensuring consistent code style across our JavaScript and TypeScript code.
+
+## Why Prettier? 🤔
+
+Prettier is an opinionated code formatter that helps us maintain a consistent code style throughout our codebase. Some key benefits include:
+
+- **Consistent formatting** 📏 - Ensures that all code looks the same, regardless of who wrote it
+- **Reduces code review overhead** 🔍 - By automating code formatting, we can focus on the logic and functionality during code reviews
+- **Improves readability** 📖 - Makes code more maintainable and easier to understand for all contributors
+- **Integrates with editors** 🛠️ - Works seamlessly with popular code editors and IDEs
+
+## Configuration
+
+Our Prettier configuration is defined in [prettier.config.ts](./prettier.config.ts). This configuration:
+
+- Sets the maximum line length to 80 characters
+- Enforces the use of single quotes for strings
+- Ensures trailing commas are used where possible
+
+## Usage
+
+You can run Prettier from the project root using:
+
+```bash
+npm run format
+```
+
+This command is configured in the root `package.json` file and will format all JavaScript and TypeScript files in the `src` directory.
+
+To check for formatting issues without making changes:
+
+```bash
+npm run format:check
+```
+
+## Official Documentation 📚
+
+For more information about Prettier and how to customize its configuration, check out:
+
+- [Prettier Official Documentation](https://prettier.io/docs/en/index.html)
+
+## Integration
+
+This Prettier configuration works alongside our ESLint setup to provide comprehensive code quality and formatting for our codebase. Together, they help us maintain high-quality, readable, and consistent code throughout the project lifecycle.

--- a/config/prettier/prettier.config.ts
+++ b/config/prettier/prettier.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'prettier';
+
+export default defineConfig({
+  printWidth: 80,
+  singleQuote: true,
+  trailingComma: 'all',
+});


### PR DESCRIPTION
Add Prettier configuration and workflow to the project.

* Add `config/prettier/prettier.config.ts` with TypeScript configuration for Prettier.
* Add `config/prettier/README.md` with Prettier configuration details.
* Update `README.md` to include a pink Prettier badge.
* Add `.github/workflows/lint-prettier-vitest.yaml` to run ESLint, Prettier, and Vitest, but do not fail for ESLint or Prettier.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sds9/console-tools-js/pull/11?shareId=f3e7d3e0-e4a6-44bd-9046-e4c3167bff8b).