### PR TITLE
Do not run the prettier lint and test workflow for release-please generated PRs

### DIFF
--- a/.github/workflows/lint-prettier-vitest.yaml
+++ b/.github/workflows/lint-prettier-vitest.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/.release-please-config.json'
+      - '**/.release-please-manifest.json'
+    branches-ignore:
+      - 'release-please/**'
 
 jobs:
   lint-prettier-vitest:


### PR DESCRIPTION
Add ignore filters to the `lint-prettier-vitest.yaml` workflow to exclude release-please generated PRs.

* Add `paths-ignore` filter to `pull_request` event to ignore `release-please` generated PRs
* Add `release-please` to the `paths-ignore` filter
* Add `branches-ignore` filter to `pull_request` event to ignore `release-please` generated PRs

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sds9/console-tools-js/pull/16?shareId=6bded615-891f-4c8d-9394-b49d735fd549).