### PR TITLE
Add a Jupyter notebook to try this code out

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,25 @@ enum BackgroundColor {
   RED = '41'
 }
 ```
+
+## Jupyter Notebook
+
+To demonstrate the usage of the `formatText` function with various styles, you can use the provided Jupyter notebook.
+
+### Installation
+
+First, install Jupyter as a development dependency:
+
+```bash
+npm install --save-dev jupyter
+```
+
+### Starting the Jupyter Notebook Server
+
+To start the Jupyter notebook server, run the following command:
+
+```bash
+npm run start:jupyter
+```
+
+This will open the Jupyter notebook interface in your default web browser. From there, you can navigate to the `notebooks` directory and open the `console-tools-js-demo.ipynb` notebook to see examples of how to use the `formatText` function.

--- a/notebooks/console-tools-js-demo.ipynb
+++ b/notebooks/console-tools-js-demo.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Console Tools JS Demo\n",
+    "\n",
+    "This notebook demonstrates the usage of the `formatText` function from the `console-tools-js` package with various styles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { formatText, FontColor, BackgroundColor } from 'console-tools-js';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bold Text\n",
+    "\n",
+    "The following example shows how to format text in bold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const boldText = formatText('This is bold text', { bold: true });\n",
+    "console.log(boldText);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Italic Text\n",
+    "\n",
+    "The following example shows how to format text in italic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const italicText = formatText('This is italic text', { italic: true });\n",
+    "console.log(italicText);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Underline Text\n",
+    "\n",
+    "The following example shows how to format text with an underline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const underlineText = formatText('This is underlined text', { underline: true });\n",
+    "console.log(underlineText);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Font Color\n",
+    "\n",
+    "The following example shows how to format text with a specific font color."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const redText = formatText('This is red text', { fontColor: FontColor.RED });\n",
+    "console.log(redText);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Background Color\n",
+    "\n",
+    "The following example shows how to format text with a specific background color."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const highlightedText = formatText('This is highlighted text', { backgroundColor: BackgroundColor.YELLOW });\n",
+    "console.log(highlightedText);"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "JavaScript",
+   "language": "javascript",
+   "name": "javascript"
+  },
+  "language_info": {
+   "name": "javascript"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prepare": "npm run clean && npm run build",
     "test": "vitest run --config ./config/vitest/vitest.config.ts",
     "test:watch": "vitest --config ./config/vitest/vitest.config.ts",
-    "lint": "npx --node-options='--experimental-strip-types --no-warnings' eslint --flag unstable_native_nodejs_ts_config --config ./config/eslint/eslint.config.ts"
+    "lint": "npx --node-options='--experimental-strip-types --no-warnings' eslint --flag unstable_native_nodejs_ts_config --config ./config/eslint/eslint.config.ts",
+    "start:jupyter": "jupyter notebook"
   },
   "repository": {
     "type": "git",
@@ -41,7 +42,8 @@
     "jiti": "^2.4.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "jupyter": "^1.0.0"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Add a Jupyter notebook to demonstrate the usage of the `formatText` function.

* **Jupyter Notebook**: Add `notebooks/console-tools-js-demo.ipynb` to demonstrate the usage of `formatText` function with various styles including bold, italic, underline, font color, and background color. Include markdown cells to explain each example and its output.
* **package.json**: Add `jupyter` as a development dependency. Add a script to start the Jupyter notebook server.
* **README.md**: Add a section on how to use the Jupyter notebook. Include instructions to install Jupyter and start the notebook server.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sds9/console-tools-js/pull/17?shareId=31912af9-456b-447b-9d98-41bc35ae72f1).