### PR TITLE
Fix invalid workflow file

### DIFF
--- a/.github/workflows/lint-prettier-vitest.yaml
+++ b/.github/workflows/lint-prettier-vitest.yaml
@@ -10,8 +10,6 @@ on:
     paths-ignore:
       - '**/.release-please-config.json'
       - '**/.release-please-manifest.json'
-    branches-ignore:
-      - 'release-please/**'
 
 jobs:
   lint-prettier-vitest:


### PR DESCRIPTION
Update `.github/workflows/lint-prettier-vitest.yaml` to define only one of `branches` or `branches-ignore` for the `pull_request` event.

* Remove `branches-ignore` from the `pull_request` event.
* Keep `branches` and `paths-ignore` in the `pull_request` event.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sds9/console-tools-js/pull/19?shareId=b6914225-8c29-46bd-887f-595174a789cd).