### PR TITLE
Fix invalid properties in dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,18 +5,15 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
-    versioning-strategy: "increase"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "main"
-    versioning-strategy: "increase"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "main"
-    versioning-strategy: "increase"


### PR DESCRIPTION
Remove invalid `versioning-strategy` properties from `.github/dependabot.yaml`.

* Remove `versioning-strategy` property from the first update entry.
* Remove `versioning-strategy` property from the second update entry.
* Remove `versioning-strategy` property from the third update entry.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sds9/console-tools-js/pull/20?shareId=e9c89a50-ef0d-44aa-91ff-403255949975).