### PR TITLE
Add npm package release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 JavaScript/TypeScript execution utilities for text formatting.
 
+[![npm version](https://img.shields.io/npm/v/console-tools-js.svg?style=flat&logo=npm)](https://www.npmjs.com/package/console-tools-js)
 [![ESLint](https://img.shields.io/badge/-ESLint-4B32C3?style=flat&logo=eslint&logoColor=white)](config/eslint/README.md)
 [![Prettier](https://img.shields.io/badge/-Prettier-FF69B4?style=flat&logo=prettier&logoColor=white)](config/prettier/README.md)
 [![Vitest](https://img.shields.io/badge/-Vitest-6E40C9?style=flat&logo=vitest&logoColor=white)](config/vitest/README.md)


### PR DESCRIPTION
Add a badge linking to the current release of the npm package in the `README.md`.

* Add a badge for the npm package release using shields.io service
* Place the badge at the top of the file, next to the existing badges
* Link the badge to the npm package page

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sds9/console-tools-js/pull/24?shareId=7918beca-f3c2-455f-8c24-2e84a147a411).